### PR TITLE
Import information from child <desc> tags as attr.description

### DIFF
--- a/svg.import.js
+++ b/svg.import.js
@@ -113,6 +113,19 @@ SVG.extend(SVG.Container, {
       }
       
       if (element) {
+
+        /* convert any child <desc> tags to a .description attribute instead */ 
+        for (var j=0;j<child.childNodes.length;j++) {
+          var grandchild = child.childNodes[j]
+          if (grandchild.nodeName.toLowerCase() == 'desc') {
+            if (!attr.description) 
+              attr.description = ''
+            else
+              attr.description += '|'
+            attr.description += grandchild.textContent
+          }
+        }
+
         /* set attributes */
         element.attr(attr)
         if (element.attr('id'))


### PR DESCRIPTION
Not sure if you'll want this change in the main branch as it's non standard.  However, it was a quick and convenient way of getting <desc> information in from my externally generated SVG into my application.

It's probably not much harder to created actual <desc> nodes - I just didn't take the time to explore that.
