### PR TITLE
Allow and ignore text nodes in gradient element

### DIFF
--- a/svg.import.js
+++ b/svg.import.js
@@ -82,7 +82,7 @@
         case 'radialgradient':
           element = context.defs().gradient(type.split('gradient')[0], function(stop) {
             for (var j = 0; j < child.childNodes.length; j++) {
-                if (child.childNodes[j].nodeType === '1') {
+                if (child.childNodes[j].nodeType === 1) {
                 
                   stop
                     .at(objectifyAttributes(child.childNodes[j]))


### PR DESCRIPTION
getAttribute was throwing an error on text nodes contained in a
lineargradient element. This ensures they are elements first.
