### PR TITLE
IE 9 console problem

### DIFF
--- a/svg.import.js
+++ b/svg.import.js
@@ -192,7 +192,8 @@
         if (this._importStore[key]) {
           var oldKey = key
           key += Math.round(Math.random() * 1e16)
-          console.warn('Encountered duplicate id "' + oldKey + '". Changed store key to "' + key + '".')
+	  if(console && console.log)
+            console.warn('Encountered duplicate id "' + oldKey + '". Changed store key to "' + key + '".')
         }
 
         this._importStore[key] = element


### PR DESCRIPTION
Console message fails under IE - in that browser console is only defined if dev tools are opened.

Introduced check for console existence, and message is output only if object exists.
