### PR TITLE
Very tiny bug fix: variable was not reseted in cycle and is used several times

### DIFF
--- a/svg.import.js
+++ b/svg.import.js
@@ -9,6 +9,7 @@
       child = nodes[i]
       attr  = {}
       clips = []
+      element = null
       
       /* get node type */
       type = child.nodeName.toLowerCase()


### PR DESCRIPTION
If this variable is not reseted at the begining of cycle there are warnings like:
`Encountered duplicate id "SvgjsPolygon1067". Changed store key to "SvgjsPolygon10676079120791982859".`
And the element is duplicated
